### PR TITLE
Updated error handling.

### DIFF
--- a/backbone-request.js
+++ b/backbone-request.js
@@ -52,7 +52,7 @@ backboneRequest.sync = function(method, model, options) {
   _.extend(params, options);
 
   request({ url: params.url, json: true, method: params.type, headers: params.headers }, function (err, result, body) {
-    if (err) {
+    if(err || result.statusCode >= 400) {
       return options.error(err);
     }
     return options.success(body);


### PR DESCRIPTION
A backbone error should be fired when the response code is >=400. Everything from there on is an error: https://developer.mozilla.org/en-US/docs/HTTP/HTTP_response_codes
